### PR TITLE
Cleanup after non branch links

### DIFF
--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -293,6 +293,11 @@ public class BranchSDK extends CordovaPlugin {
         if (data != null && data.isHierarchical()) {
             this.deepLinkUrl = data.toString();
         }
+        
+        // Since the plugin does not cleanup after non branch links this results in duplication of deeplinks
+        // returning the same deep link on app resume instead of only the first time
+        // setting it to empty string instead of Null to prevent crashes but also cleanup.
+        activity.getIntent().setData(Uri.parse(""));
 
         this.instance.initSession(new SessionListener(callbackContext), data, activity);
     }


### PR DESCRIPTION
Cleans up after the deep link is consumed because otherwise it will make the app try deeplinking every time. Branch cleans up after itself for branch links but doesn't for non branch links. Related to braze in app messages.