### PR TITLE
JOY-11454: Fix: The method to obtain last attributed touch data now i…

### DIFF
--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -791,7 +791,7 @@ NSString * const pluginVersion = @"4.1.3";
   NSMutableDictionary *json = [NSMutableDictionary new];
 
   Branch *branch = [self getInstance];
-  [branch lastAttributedTouchDataWithAttributionWindow:30 completion:^(BranchLastAttributedTouchData * _Nullable latd) {
+  [branch lastAttributedTouchDataWithAttributionWindow:30 completion:^(BranchLastAttributedTouchData * _Nullable latd, NSError * _Nullable error) {
     CDVPluginResult* pluginResult = nil;
     if (latd) {
       [json setObject:latd.attributionWindow forKey:@"attribution_window"];


### PR DESCRIPTION
…ncludes an NSError in the completion block

Following what's stated in:

- https://www.devscope.io/code/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/issues/687
- https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/pull/688
- https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/blob/master/ChangeLog.md